### PR TITLE
chore(config): streamline application.yaml configuration

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,17 +1,10 @@
+server:
+  port: ${PORT:8080}
+
 spring:
   r2dbc:
-    url: ${R2DBC_DATABASE_URL}
+    url: ${R2DBC_DATABASE_URL:r2dbc:postgresql://localhost:5432/dummy}
   main:
     web-application-type: reactive
   application:
     name: foodplease-backend
-
-flyway:
-  enabled: false
-
-server:
-  port: ${PORT:8080}
-
-logging:
-  level:
-    root: INFO


### PR DESCRIPTION
- Reordered and cleaned up `application.yaml` entries for improved clarity.
- Moved `server.port` to the top and ensured default value fallback.
- Provided a default fallback value for `R2DBC_DATABASE_URL`.
- Removed unnecessary Flyway and logging configurations.