### PR TITLE
feat(security): enable actuator endpoints and monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     // WebFlux y Seguridad
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/sdch/foodpleasebackend/configuration/SecurityConfig.java
+++ b/src/main/java/com/sdch/foodpleasebackend/configuration/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
     return http
             .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .authorizeExchange(auth -> auth
-                    .pathMatchers("/auth/login").permitAll()
+                    .pathMatchers("/auth/login", "/actuator/**").permitAll()
                     .pathMatchers(HttpMethod.OPTIONS).permitAll()
                     .pathMatchers("/api/**").authenticated()
                     .anyExchange().permitAll()


### PR DESCRIPTION
- Added `spring-boot-starter-actuator` dependency in `build.gradle` for application monitoring.
- Updated `SecurityConfig.java` to permit access to `/actuator/**` endpoints without authentication.
- Ensured actuator integration aligns with security configuration and access policies.