### PR TITLE
feat(config): secure database URL and expose actuator health endpoint

### DIFF
--- a/src/main/java/com/sdch/foodpleasebackend/configuration/SecurityConfig.java
+++ b/src/main/java/com/sdch/foodpleasebackend/configuration/SecurityConfig.java
@@ -24,12 +24,13 @@ public class SecurityConfig {
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }
+
   @Bean
   public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
     return http
             .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .authorizeExchange(auth -> auth
-                    .pathMatchers("/auth/login", "/actuator/**").permitAll()
+                    .pathMatchers("/auth/login").permitAll()
                     .pathMatchers(HttpMethod.OPTIONS).permitAll()
                     .pathMatchers("/api/**").authenticated()
                     .anyExchange().permitAll()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,8 +3,18 @@ server:
 
 spring:
   r2dbc:
-    url: ${R2DBC_DATABASE_URL:r2dbc:postgresql://localhost:5432/dummy}
+    url: ${R2DBC_DATABASE_URL:r2dbc:postgresql://food_please_user:food_please_pass@localhost:5432/food_please}
   main:
     web-application-type: reactive
   application:
     name: foodplease-backend
+
+management:
+  endpoints:
+    web:
+      base-path: /
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
- Updated `application.yaml` to use a full R2DBC URL with credentials and database name.
- Configured management settings to expose the health endpoint at the root path with detailed information.
- Removed actuator path from permitted routes in `SecurityConfig.java` to limit access as per new actuator configuration.