### PR TITLE
feat(user): add user creation endpoint and tests

### DIFF
--- a/src/main/java/com/sdch/foodpleasebackend/handler/UserHandler.java
+++ b/src/main/java/com/sdch/foodpleasebackend/handler/UserHandler.java
@@ -1,5 +1,7 @@
 package com.sdch.foodpleasebackend.handler;
 
+import com.sdch.foodpleasebackend.model.User;
+import com.sdch.foodpleasebackend.service.UserService;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -10,6 +12,12 @@ import reactor.core.publisher.Mono;
 @Component
 public class UserHandler {
 
+  private final UserService userService;
+
+  public UserHandler(UserService userService) {
+    this.userService = userService;
+  }
+
   public Mono<ServerResponse> me(ServerRequest request) {
     return ReactiveSecurityContextHolder.getContext()
         .map(ctx -> ctx.getAuthentication().getPrincipal())
@@ -18,5 +26,16 @@ public class UserHandler {
                 ServerResponse.ok()
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue("{\"user\":\"" + principal.toString() + "\"}"));
+  }
+
+  public Mono<ServerResponse> createUser(ServerRequest request) {
+    return request
+        .bodyToMono(User.class)
+        .flatMap(userService::createUser)
+        .flatMap(
+            savedUser ->
+                ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).bodyValue(savedUser))
+        .onErrorResume(
+            e -> ServerResponse.badRequest().bodyValue("{\"error\":\"" + e.getMessage() + "\"}"));
   }
 }

--- a/src/main/java/com/sdch/foodpleasebackend/router/UserRouter.java
+++ b/src/main/java/com/sdch/foodpleasebackend/router/UserRouter.java
@@ -1,18 +1,23 @@
 package com.sdch.foodpleasebackend.router;
 
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
 import com.sdch.foodpleasebackend.handler.UserHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Configuration
 public class UserRouter {
 
   @Bean
-  public RouterFunction<?> userRoutes(UserHandler userHandler) {
-    return route(GET("/api/me"), userHandler::me);
+  public RouterFunction<ServerResponse> userRoutes(UserHandler userHandler) {
+    return route(GET("/api/me"), userHandler::me)
+            .andRoute(POST("/api/users").and(accept(MediaType.APPLICATION_JSON)), userHandler::createUser);
   }
 }

--- a/src/test/java/com/sdch/foodpleasebackend/handler/AuthHandlerIntegrationTest.java
+++ b/src/test/java/com/sdch/foodpleasebackend/handler/AuthHandlerIntegrationTest.java
@@ -7,6 +7,7 @@ import com.sdch.foodpleasebackend.dto.AuthRequest;
 import com.sdch.foodpleasebackend.dto.AuthResponse;
 import com.sdch.foodpleasebackend.model.User;
 import com.sdch.foodpleasebackend.router.AuthRouter;
+import com.sdch.foodpleasebackend.router.UserRouter;
 import com.sdch.foodpleasebackend.service.UserService;
 import com.sdch.foodpleasebackend.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +26,12 @@ import reactor.core.publisher.Mono;
 
 @ActiveProfiles("test")
 @SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-      "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration"
-    })
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration"
+        })
 @AutoConfigureWebTestClient
-@Import({AuthHandler.class, AuthRouter.class, JwtUtil.class})
+@Import({AuthHandler.class, UserHandler.class, AuthRouter.class, UserRouter.class, JwtUtil.class})
 class AuthHandlerIntegrationTest {
 
   private static final String USERNAME = "admin";
@@ -49,45 +50,41 @@ class AuthHandlerIntegrationTest {
 
   @Test
   void loginAndAccessProtectedRoute_shouldSucceed_withValidToken() {
-    // Arrange
     User user = new User();
     user.setUsername(USERNAME);
     user.setPassword(HASHED);
+
     when(userService.findByUsername(USERNAME)).thenReturn(Mono.just(user));
     when(passwordEncoder.matches(PASSWORD, HASHED)).thenReturn(true);
 
-    // Act
     AuthRequest request = new AuthRequest();
     request.setUsername(USERNAME);
     request.setPassword(PASSWORD);
 
     String token =
-        webTestClient
-            .post()
-            .uri("/auth/login")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(request)
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody(AuthResponse.class)
-            .returnResult()
-            .getResponseBody()
-            .getToken();
+            webTestClient
+                    .post()
+                    .uri("/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody(AuthResponse.class)
+                    .returnResult()
+                    .getResponseBody()
+                    .getToken();
 
-    // Assert
     assertThat(token).isNotNull();
 
     webTestClient
-        .get()
-        .uri("/api/me")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-        .exchange()
-        .expectStatus()
-        .isOk()
-        .expectBody()
-        .jsonPath("$.user")
-        .isEqualTo(USERNAME);
+            .get()
+            .uri("/api/me")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.user")
+            .isEqualTo(USERNAME);
   }
 
   @Test
@@ -137,17 +134,63 @@ class AuthHandlerIntegrationTest {
 
   @Test
   void accessProtectedRoute_shouldFail_ifTokenMissing() {
-    webTestClient.get().uri("/api/me").exchange().expectStatus().isUnauthorized();
+    webTestClient
+            .get()
+            .uri("/api/me")
+            .exchange()
+            .expectStatus().isUnauthorized();
   }
 
   @Test
   void accessProtectedRoute_shouldFail_ifTokenInvalid() {
     webTestClient
-        .get()
-        .uri("/api/me")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer faketoken123")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized();
+            .get()
+            .uri("/api/me")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer faketoken123")
+            .exchange()
+            .expectStatus().isUnauthorized();
+  }
+
+  @Test
+  void createUser_shouldSucceed_withValidInput() {
+    String token = jwtUtil.generateToken(USERNAME);
+
+    User userToCreate = new User();
+    userToCreate.setUsername(USERNAME);
+    userToCreate.setPassword(PASSWORD);
+
+    User savedUser = new User();
+    savedUser.setUsername(USERNAME);
+    savedUser.setPassword("hashed-secret");
+
+    when(userService.createUser(any(User.class))).thenReturn(Mono.just(savedUser));
+
+    webTestClient
+            .post()
+            .uri("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .bodyValue(userToCreate)
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.username").isEqualTo("admin")
+            .jsonPath("$.password").isEqualTo("hashed-secret");
+  }
+
+  @Test
+  void me_shouldSucceed_withValidToken() {
+    String token = jwtUtil.generateToken(USERNAME);
+
+    webTestClient
+            .get()
+            .uri("/api/me")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .exchange()
+            .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.user").isEqualTo(USERNAME);
   }
 }


### PR DESCRIPTION
- Implemented `createUser` method in `UserHandler` to handle POST requests for new user creation.
- Updated `UserRouter` to include the `/api/users` POST route with JSON content type requirement.
- Enhanced `AuthHandlerIntegrationTest`:
  - Registered `UserHandler` and `UserRouter` for test context.
  - Added test to verify user creation via `/api/users`.
  - Added assertion to check returned JSON fields for user creation response.
  - Ensured existing token-based tests still function with the integrated router.